### PR TITLE
Fix water and light

### DIFF
--- a/COMP371/ChunkManager.h
+++ b/COMP371/ChunkManager.h
@@ -43,7 +43,7 @@ public:
 	static const int32 CHUNKWIDTH = 32;
 	static const uint32 CHUNKHEIGHT = 256;
 	static const uint32 NUMBEROFBLOCKS = CHUNKWIDTH*CHUNKWIDTH*CHUNKHEIGHT;
-	static const int32 LOADINGRADIUS = 5;
+	static const int32 LOADINGRADIUS = 6;
 
 	const std::unordered_map<int64, Chunk>& getCurrentlyLoadedChunks() const { return cmLoadedChunks; };
 

--- a/COMP371/LightSource.cpp
+++ b/COMP371/LightSource.cpp
@@ -3,10 +3,8 @@
 #include "RenderingContext.h"
 
 // Light caster constructor
-LightSource::LightSource(glm::vec3 direction, glm::vec3 color, float32 ambStrength, float32 specStrength)
+LightSource::LightSource(glm::vec3 direction, glm::vec3 color)
 	: m_color(color)
-	, m_ambStrength(ambStrength)
-	, m_specStrength(specStrength)
 {
 	m_type = SourceType::DIRECTIONAL;
 	m_direction = glm::normalize(-direction);
@@ -14,11 +12,9 @@ LightSource::LightSource(glm::vec3 direction, glm::vec3 color, float32 ambStreng
 }
 
 // Point light constructor
-LightSource::LightSource(glm::vec3 position, glm::vec3 direction, glm::vec3 color, float32 ambStrength, float32 specStrength)
+LightSource::LightSource(glm::vec3 position, glm::vec3 direction, glm::vec3 color)
 	: m_color(color)
 	, m_position(position)
-	, m_ambStrength(ambStrength)
-	, m_specStrength(specStrength)
 {
 	m_type = SourceType::POINT;
 	m_direction = glm::normalize(-direction);
@@ -31,8 +27,6 @@ void LightSource::initShaders()
 	if (m_type == SourceType::POINT) { chunkShader->setUniform("lightPosition", m_position); }
 	chunkShader->setUniform("lightColor", m_color);
 	chunkShader->setUniform("lightDirection", m_direction);
-	chunkShader->setUniform("ambientStrength", m_ambStrength);
-	chunkShader->setUniform("specularStrength", m_specStrength);
 }
 
 LightSource::~LightSource()

--- a/COMP371/LightSource.h
+++ b/COMP371/LightSource.h
@@ -16,20 +16,14 @@ enum class SourceType
 struct LightSource
 {
 public:
-	LightSource(glm::vec3 position, glm::vec3 direction, glm::vec3 color, float32 ambientStrength, float32 specStrength);
-	LightSource(glm::vec3 direction, glm::vec3 color, float32 ambientStrength, float32 specStrength);
+	LightSource(glm::vec3 position, glm::vec3 direction, glm::vec3 color);
+	LightSource(glm::vec3 direction, glm::vec3 color);
 	~LightSource();
 
-	glm::vec3 getColor() { return m_color; }
-	glm::vec3 getDirection() { return m_direction; }
-	float32 getAmbStrength() { return m_ambStrength; }
-	float32 getSpecStrength() { return m_specStrength; }
-
+	glm::vec3 getColor() const { return m_color; }
+	glm::vec3 getDirection() const { return m_direction; }
 private:
 	void initShaders();
-
-	float32 m_ambStrength;
-	float32 m_specStrength;
 
 	SourceType m_type;
 

--- a/COMP371/Main.cpp
+++ b/COMP371/Main.cpp
@@ -186,7 +186,7 @@ GLFWwindow* initGLFW() {
 
 	glfwDefaultWindowHints();
 	// 8x MSAA
-	//glfwWindowHint(GLFW_SAMPLES, 8);
+	glfwWindowHint(GLFW_SAMPLES, 8);
 
 	GLFWwindow* window = glfwCreateWindow(SCREENWIDTH, SCREENHEIGHT, "Final Project", nullptr, nullptr);
 
@@ -253,7 +253,7 @@ void render() {
 
 	//First Pass (Shadows)
 	RenderingContext::get()->shaderCache.getShaderProgram("sm_shader")->use();
-	shadowMap->updateMvp(lightDirection);
+	shadowMap->updateMVP(lightDirection);
 	shadowMap->bindForWriting();
 	glClear(GL_DEPTH_BUFFER_BIT);
 #ifdef RENDER_SHADOWS

--- a/COMP371/Main.cpp
+++ b/COMP371/Main.cpp
@@ -273,12 +273,14 @@ void render() {
 	chunkTexture->bind(Texture::UNIT_0);
 	shadowMap->bindForReading();
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+#ifdef RENDER_WATER
 	glEnable(GL_CLIP_DISTANCE0);
 	for (const auto& chunk : chunks) {
 		glBindVertexArray(chunk.second.getVao());
 		glDrawElementsInstanced(GL_TRIANGLES, cube::numIndices, GL_UNSIGNED_INT, nullptr, chunk.second.getBlockCount());
 	}
 	glDisable(GL_CLIP_DISTANCE0);
+#endif
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
 	// Render chunks

--- a/COMP371/Main.cpp
+++ b/COMP371/Main.cpp
@@ -269,6 +269,7 @@ void render() {
 	chunkShader->setUniform("waterPlaneHeight", WaterRenderer::get()->getY());
 	chunkShader->setUniform("lightSpaceMatrix", shadowMap->getMVP());
 	chunkTexture->bind(Texture::UNIT_0);
+	shadowMap->bindTexture(Texture::UNIT_1);
 	glBindFramebuffer(GL_FRAMEBUFFER, WaterRenderer::get()->getRefractionFBO());
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 	glEnable(GL_CLIP_DISTANCE0);

--- a/COMP371/Main.cpp
+++ b/COMP371/Main.cpp
@@ -69,6 +69,8 @@ FreeCameraController* gCameraController;
 ShaderProgram* chunkNormalsShader = nullptr;
 #endif
 
+#define RENDER_WATER // Comment me if you don't want to render water
+
 int main() {
 
 	try {
@@ -125,10 +127,12 @@ int main() {
 	chunkShader->use();
 	chunkShader->setUniform("faceData", faceData);
 
-	glm::vec3 lightColor(0.9f, 0.9f, 0.9f);
+	glm::vec3 lightColor(1.0f, 1.0f, 1.0f);
 
-	sun = new LightSource(lightDirection, lightColor, 0.5f, 0.01f);
+	sun = new LightSource(lightDirection, lightColor);
 	shadowMap = new ShadowMap(SCREENWIDTH, SCREENHEIGHT, lightDirection);
+
+	WaterRenderer::get()->setLightUniforms(*sun);
 
 	// Start loop
 	uint32 frames = 0;
@@ -296,12 +300,14 @@ void render() {
 	}
 
 	// Render water
+#ifdef RENDER_WATER
 	for (const auto& chunk : chunks) {
 		glm::vec3 pos = chunk.second.getPosition();
 
 		// Render water
 		WaterRenderer::get()->render(pos.x, pos.z, ChunkManager::CHUNKWIDTH);
 	}
+#endif
 
 	// Render test cube
 	cubeShader->use();

--- a/COMP371/ShadowMap.cpp
+++ b/COMP371/ShadowMap.cpp
@@ -21,13 +21,13 @@ ShadowMap::ShadowMap(uint32 width, uint32 height, glm::vec3 lightDirection)
 
 void ShadowMap::updateMvp(const glm::vec3& lightDirection)
 {
-	glm::vec3 invLightDirection = glm::normalize(-lightDirection);
+	glm::vec3 invLightDirection = glm::normalize(-lightDirection) * 500.0f;
 	glm::vec3 playerPos = RenderingContext::get()->camera.transform.getPosition();
-	glm::vec3 lightPosition = (invLightDirection*500.0f);
+	glm::vec3 lightPosition = { playerPos.x + invLightDirection.x, invLightDirection.y, playerPos.z + invLightDirection.z };
 	float32 loadingRadius = (ChunkManager::LOADINGRADIUS + 0.5) * ChunkManager::CHUNKWIDTH;
 
 	glm::mat4 proj = glm::ortho<float>(-loadingRadius, loadingRadius, 0, ChunkManager::CHUNKHEIGHT, 0.1f , 1000.0f);
-	glm::mat4 view = glm::lookAt(lightPosition, glm::vec3(0, 0, 0), glm::vec3(0, 1, 0));
+	glm::mat4 view = glm::lookAt(lightPosition, glm::vec3(playerPos.x, 0, playerPos.z), glm::vec3(0, 1, 0));
 	glm::mat4 mod = glm::mat4(1.0f);
 	
 	m_lightSpaceMVP = proj * view * mod;

--- a/COMP371/ShadowMap.cpp
+++ b/COMP371/ShadowMap.cpp
@@ -21,12 +21,12 @@ ShadowMap::ShadowMap(uint32 width, uint32 height, glm::vec3 lightDirection)
 
 void ShadowMap::updateMvp(const glm::vec3& lightDirection)
 {
-	glm::vec3 invLightDirection = glm::normalize(-lightDirection) * 500.0f;
+	glm::vec3 invLightDirection = glm::normalize(-lightDirection) * 300.0f;
 	glm::vec3 playerPos = RenderingContext::get()->camera.transform.getPosition();
 	glm::vec3 lightPosition = { playerPos.x + invLightDirection.x, invLightDirection.y, playerPos.z + invLightDirection.z };
 	float32 loadingRadius = (ChunkManager::LOADINGRADIUS + 0.5) * ChunkManager::CHUNKWIDTH;
 
-	glm::mat4 proj = glm::ortho<float>(-loadingRadius, loadingRadius, 0, ChunkManager::CHUNKHEIGHT, 0.1f , 1000.0f);
+	glm::mat4 proj = glm::ortho<float>(-(loadingRadius+50), (loadingRadius+50), 0, ChunkManager::CHUNKHEIGHT, 0.1f , 500.0f);
 	glm::mat4 view = glm::lookAt(lightPosition, glm::vec3(playerPos.x, 0, playerPos.z), glm::vec3(0, 1, 0));
 	glm::mat4 mod = glm::mat4(1.0f);
 	
@@ -67,9 +67,15 @@ void ShadowMap::buildFBO()
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
 
-void ShadowMap::bindTexture(Texture::Unit unit)
+void ShadowMap::bindForWriting()
 {
-	glActiveTexture(unit);
+	glBindFramebuffer(GL_FRAMEBUFFER, m_shadowFBO);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, m_depthTexture, 0);
+}
+
+void ShadowMap::bindForReading()
+{
+	glActiveTexture(Texture::UNIT_1);
 	glBindTexture(GL_TEXTURE_2D, m_depthTexture);
 }
 

--- a/COMP371/ShadowMap.cpp
+++ b/COMP371/ShadowMap.cpp
@@ -6,6 +6,7 @@
 
 #include "RenderingContext.h"
 #include "ChunkManager.h"
+#include "ShaderProgram.h"
 
 #include <iostream>
 
@@ -13,37 +14,41 @@ ShadowMap::ShadowMap(uint32 width, uint32 height, glm::vec3 lightDirection)
 	:m_width(width)
 	,m_height(height)
 {
+	m_shadowShader = RenderingContext::get()->shaderCache.loadShaderProgram("sm_shader", "shadowmap_vert.glsl", "shadowmap_frag.glsl");
 	updateMvp(lightDirection);
-	buildBuffer();
+	buildFBO();
 }
 
-void ShadowMap::updateMvp(glm::vec3 lightDirection)
+void ShadowMap::updateMvp(const glm::vec3& lightDirection)
 {
 	glm::vec3 invLightDirection = glm::normalize(-lightDirection);
 	glm::vec3 playerPos = RenderingContext::get()->camera.transform.getPosition();
-	glm::vec3 lightPosition = (invLightDirection*300.0f);
+	glm::vec3 lightPosition = (invLightDirection*500.0f);
 	float32 loadingRadius = (ChunkManager::LOADINGRADIUS + 0.5) * ChunkManager::CHUNKWIDTH;
 
-	glm::mat4 proj = glm::ortho<float>(-loadingRadius, loadingRadius, 0, ChunkManager::CHUNKHEIGHT, 0.1f , 500.0f);
+	glm::mat4 proj = glm::ortho<float>(-loadingRadius, loadingRadius, 0, ChunkManager::CHUNKHEIGHT, 0.1f , 1000.0f);
 	glm::mat4 view = glm::lookAt(lightPosition, glm::vec3(0, 0, 0), glm::vec3(0, 1, 0));
 	glm::mat4 mod = glm::mat4(1.0f);
 	
-	m_MVP = proj * view * mod;
+	m_lightSpaceMVP = proj * view * mod;
+
+	m_shadowShader->use();
+	m_shadowShader->setUniform("lightSpaceMatrix", m_lightSpaceMVP);
 }
 
 void ShadowMap::updateSize(int32 width, int32 height)
 {
 	m_width = width;
 	m_height = height;
-	glDeleteFramebuffers(1, &m_fbo);
-	glDeleteTextures(1, &m_texture);
-	buildBuffer();
+	glDeleteFramebuffers(1, &m_shadowFBO);
+	glDeleteTextures(1, &m_depthTexture);
+	buildFBO();
 }
 
-void ShadowMap::buildBuffer()
+void ShadowMap::buildFBO()
 {
-	glGenTextures(1, &m_texture);
-	glBindTexture(GL_TEXTURE_2D, m_texture);
+	glGenTextures(1, &m_depthTexture);
+	glBindTexture(GL_TEXTURE_2D, m_depthTexture);
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, m_width, m_height, 0, GL_DEPTH_COMPONENT, GL_FLOAT, 0);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
@@ -53,14 +58,23 @@ void ShadowMap::buildBuffer()
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 	glBindTexture(GL_TEXTURE_2D, 0);
 	
-	glGenFramebuffers(1, &m_fbo);
-	glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
-	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, m_texture, 0);
+	glGenFramebuffers(1, &m_shadowFBO);
+	glBindFramebuffer(GL_FRAMEBUFFER, m_shadowFBO);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, m_depthTexture, 0);
 	glDrawBuffer(GL_NONE);
 	glReadBuffer(GL_NONE);
 
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
+
+void ShadowMap::bindTexture(Texture::Unit unit)
+{
+	glActiveTexture(unit);
+	glBindTexture(GL_TEXTURE_2D, m_depthTexture);
+}
+
 ShadowMap::~ShadowMap()
 {
+	glDeleteFramebuffers(1, &m_shadowFBO);
+	glDeleteTextures(1, &m_depthTexture);
 }

--- a/COMP371/ShadowMap.h
+++ b/COMP371/ShadowMap.h
@@ -1,35 +1,37 @@
 #pragma once
 
 #include "Types.h"
-#include "ShaderProgram.h"
+#include "Texture.h"
 
 #include "glm\glm.hpp"
+
+class ShaderProgram;
+
 class ShadowMap
 {
 public:
 	ShadowMap(uint32 width, uint32 height, glm::vec3 lightDirection);
 
 	void updateSize(int32 width, int32 height);
-	void updateMvp(glm::vec3 lightDirection);
+	void updateMvp(const glm::vec3& lightDirection);
 
-	uint32 getFbo() { return m_fbo; }
-	glm::mat4 getMvp() { return m_MVP; }
-	uint32 getTexture() { return m_texture; }
+	uint32 getFbo() const { return m_shadowFBO; }
+	glm::mat4 getMVP() const { return m_lightSpaceMVP; }
+
+	void bindTexture(Texture::Unit unit);
 
 	~ShadowMap();
 private:
-	void buildBuffer();
+	void buildFBO();
 
-	//Texture dimensions
 	int32 m_width;
 	int32 m_height;
 
-	glm::mat4 m_MVP;
+	glm::mat4 m_lightSpaceMVP;
 
-	ShaderProgram* m_Shaders;
+	ShaderProgram* m_shadowShader;
 
-	//OpenGL IDs
-	uint32 m_fbo;
-	uint32 m_texture;
+	uint32 m_shadowFBO;
+	uint32 m_depthTexture;
 };
 

--- a/COMP371/ShadowMap.h
+++ b/COMP371/ShadowMap.h
@@ -13,9 +13,9 @@ public:
 	ShadowMap(uint32 width, uint32 height, glm::vec3 lightDirection);
 
 	void updateSize(int32 width, int32 height);
-	void updateMvp(const glm::vec3& lightDirection);
+	void updateMVP(const glm::vec3& lightDirection);
 
-	uint32 getFbo() const { return m_shadowFBO; }
+	uint32 getFBO() const { return m_shadowFBO; }
 	glm::mat4 getMVP() const { return m_lightSpaceMVP; }
 
 	void bindForWriting();

--- a/COMP371/ShadowMap.h
+++ b/COMP371/ShadowMap.h
@@ -18,7 +18,8 @@ public:
 	uint32 getFbo() const { return m_shadowFBO; }
 	glm::mat4 getMVP() const { return m_lightSpaceMVP; }
 
-	void bindTexture(Texture::Unit unit);
+	void bindForWriting();
+	void bindForReading();
 
 	~ShadowMap();
 private:

--- a/COMP371/WaterRenderer.cpp
+++ b/COMP371/WaterRenderer.cpp
@@ -131,3 +131,9 @@ void WaterRenderer::render(float32 x, float32 z, float32 scale) {
 	m_waterShader->setUniform("vpMatrix", RenderingContext::get()->camera.getViewProjectionMatrix());
 	glDrawElements(GL_TRIANGLES, m_numElements, GL_UNSIGNED_INT, nullptr);
 }
+
+void WaterRenderer::setLightUniforms(const LightSource& light) {
+	m_waterShader->use();
+	m_waterShader->setUniform("lightDirection", light.getDirection());
+	m_waterShader->setUniform("lightColor", light.getColor());
+}

--- a/COMP371/WaterRenderer.h
+++ b/COMP371/WaterRenderer.h
@@ -6,6 +6,8 @@
 
 #include "Chunk.h"
 
+#include "LightSource.h"
+
 class ShaderProgram;
 class Texture;
 
@@ -43,6 +45,8 @@ public:
 
 	float32 getY() const { return m_y; };
 	uint32 getRefractionFBO() const { return m_refractionFBO; };
+
+	void setLightUniforms(const LightSource& light);
 
 	static void init() { s_instance = new WaterRenderer(); };
 	static WaterRenderer* get() { return s_instance; };

--- a/COMP371/chunk_frag.glsl
+++ b/COMP371/chunk_frag.glsl
@@ -61,5 +61,5 @@ void main() {
 	tempColor = vec4((ambient + (1.0 - shadowFactor) * (diffuse + specular)), 1.0f) * tempColor;
 	
 
-	finalColor = tempColor;
+	finalColor = clamp(tempColor, 0.0, 1.0);
 }

--- a/COMP371/chunk_frag.glsl
+++ b/COMP371/chunk_frag.glsl
@@ -15,8 +15,6 @@ uniform vec3 viewPos;
 uniform vec3 lightColor;
 uniform vec3 lightDirection;
 uniform vec3 lightPos;
-uniform float ambientStrength;
-uniform float specularStrength;
 
 out vec4 finalColor;
 
@@ -35,21 +33,33 @@ void main() {
 
 	vec4 tempColor = texture(tilesheet, vec3(passFromVertex.UvCoords.x, passFromVertex.UvCoords.y, passFromVertex.faceIndex));
 
+	// Should be unique per material instead of per light so these are hardcoded for now
+	float ambientCoefficient = 0.2;
+	float diffuseCoefficient = 0.9;
+	float specularCoefficient = 0.2;
+	float shininess = 1;
+
 	//Ambient Lighting
-	vec3 ambient = ambientStrength * lightColor;
+	vec3 ambient = ambientCoefficient * lightColor;
 
 	//Diffuse Lighting
-	float diff = max(dot(passFromVertex.normal, lightDirection), 0.0);
+	float diff  = diffuseCoefficient * max(dot(passFromVertex.normal, lightDirection), 0.0);
 	vec3 diffuse = diff * lightColor;
 
 	//Specular Lighting
-	vec3 viewDir = normalize(viewPos - vec3(passFromVertex.fragPos));
-	vec3 reflectDir = reflect(-lightDirection, passFromVertex.normal);
-	float spec = pow(max(dot(viewDir, reflectDir), 0.0), 2); //CHANGE 2 TO A VARIABLE SHININESS COEFFICIENT DEPENDING ON BLOCK TYPE
-	vec3 specular = specularStrength * spec * lightColor;
+	vec3 specular = vec3(0.0, 0.0, 0.0);
+	
+	// Should not add a specular component when the diffuse dot product is 0
+	if (diff != 0.0) {
+		vec3 viewDir = normalize(viewPos - vec3(passFromVertex.fragPos));
+		vec3 reflectDir = reflect(-lightDirection, passFromVertex.normal);
+		float spec = pow(max(dot(viewDir, reflectDir), 0.0), shininess);
+		specular = specularCoefficient * spec * lightColor;
+	}
 
 	float shadowFactor = ShadowCalculation(passFromVertex.fragPosLightSpace);
 	tempColor = vec4((ambient + (1.0 - shadowFactor) * (diffuse + specular)), 1.0f) * tempColor;
+	
 
 	finalColor = tempColor;
 }

--- a/COMP371/chunk_frag.glsl
+++ b/COMP371/chunk_frag.glsl
@@ -24,7 +24,8 @@ float ShadowCalculation(vec4 fragPosLightSpace)
 	projCoords = projCoords * 0.5 + 0.5;
 	float closestDepth = texture(shadowMap, projCoords.xy).r;
 	float currentDepth = projCoords.z;
-	float shadow = currentDepth > closestDepth ? 1.0 : 0.0;
+	float bias = 0.0005;
+	float shadow = (currentDepth - bias) > closestDepth ? 1.0 : 0.0;
 
 	return shadow;
 }

--- a/COMP371/water_frag.glsl
+++ b/COMP371/water_frag.glsl
@@ -16,47 +16,66 @@ out vec4 finalColor;
 
 uniform float panner;
 
-void main() {
-	//finalColor = texture(normal, passUvCoords);
-	//135,206,250
-	vec4 tempColor = vec4(135/255.0,206/255.0,250/255.0,1);
-	//vec4 tempColor = vec4(0.0,0.0,0.2,0.4);
-	vec3 normal1 = texture(normalMap, tiledNormalUvCoords + vec2(panner,panner)).rgb;
-	vec3 normal2 = texture(normalMap2, tiledNormalUvCoords + vec2(-panner,-panner)).rgb;
-	vec3 normal = normalize(normal1 + normal2);
-	//vec3 normal = mix(normal1, normal2, 0.5);
+// Light uniforms
+uniform vec3 lightDirection;
+uniform vec3 lightColor;
 
-	// ##########################
-	vec3 lightDirection = vec3(-0.80, -0.5, 0.0);
-	vec3 lightColor = vec3(1.0,1.0,1.0);
-	float ambientStrength = 0.5;
-	float specularStrength = 1;
-	// ##########################
+void main() {
+
+	// Water color rgb(68, 103, 125)
+	vec4 tempColor = vec4(0.26666666666, 0.40392156862, 0.49019607843, 1.0);
+	
+	// Pan and sample normal maps
+	vec3 normal1 = ((texture(normalMap, tiledNormalUvCoords + vec2(panner,panner)).rgb) * 2) - 1;
+	vec3 normal2 = ((texture(normalMap2, tiledNormalUvCoords + vec2(-panner,-panner)).rgb) * 2) - 1;
+
+	// Convert normals from tangent space to world space
+	// This can be greatly simplified since we are rendering on a plane
+	normal1 = normal1.xzy;
+	normal2 = normal2.xzy;
+	
+	// Mix the normal maps together
+	vec3 normal = normalize(normal1 + normal2);
+
+
+	// Should be unique per material instead of per light so these are hardcoded for now
+	float ambientCoefficient = 0.5;
+	float diffuseCoefficient = 0.7;
+	float specularCoefficient = 3;
+	float shininess = 25;
 
 	//Ambient Lighting
-	vec3 ambient = ambientStrength * lightColor;
+	vec3 ambient = ambientCoefficient * lightColor;
 
 	//Diffuse Lighting
-	float diff = max(dot(normal, lightDirection), 0.0);
+	float diff  = diffuseCoefficient * max(dot(normal, lightDirection), 0.0);
 	vec3 diffuse = diff * lightColor;
 
 	//Specular Lighting
-	vec3 viewDir = normalize(viewPos - vec3(originalPos));
-	vec3 reflectDir = reflect(-lightDirection, normal);
-	float spec = pow(max(dot(viewDir, reflectDir), 0.0), 2); //CHANGE 2 TO A VARIABLE SHININESS COEFFICIENT DEPENDING ON BLOCK TYPE
-	vec3 specular = specularStrength * spec * lightColor;
+	vec3 specular = vec3(0.0, 0.0, 0.0);
+	
+	// Should not add a specular component when the diffuse dot product is 0
+	if (diff != 0.0) {
+		vec3 viewDir = normalize(viewPos - vec3(originalPos));
+		vec3 reflectDir = reflect(-lightDirection, normal);
+		float spec = pow(max(dot(viewDir, reflectDir), 0.0), shininess);
+		specular = specularCoefficient * spec * lightColor;
+	}
 
-	tempColor = vec4((ambient + diffuse + specular), 1.0f) * tempColor;
+	tempColor = vec4((ambient + diffuse + specular), 1.0) * tempColor;
 
 	// Convert clipSpacePosition to UV
 	vec2 screenPos = clipSpacePos.xy / clipSpacePos.w;
-	vec2 uv = vec2((screenPos.x / 2.0) + 0.5, (screenPos.y / 2.0) + 0.5);
-	vec2 dudvDisp = ((texture(dudvMap, tiledDuDvCoords + vec2(panner,panner)).rg * 2.0) - 1.0) * 0.007;
+	vec2 uv = vec2((screenPos.x / 2.0) + 0.5, (screenPos.y / 2.0) + 0.5); // Convert OpenGL screen space to uv space
+	vec2 dudvDisp = ((texture(dudvMap, tiledDuDvCoords + vec2(panner,panner)).rg * 2.0) - 1.0) * 0.007; // Adjust dudv vectors to range from -1.0 to 1.0 and reduce strength
 	
 	
+	// Mix everything together
 	finalColor = mix(tempColor, texture(refractionTexture, uv + dudvDisp), 0.5);
 	
-	//finalColor = texture(dudvMap, tiledDuDvCoords + vec2(panner,panner));
 	//finalColor = vec4(normal, 1.0);
-	//finalColor = tempColor;
+	//finalColor = vec4(specular,1.0);
+	//finalColor = vec4(diffuse, 1.0);
+	//finalColor = vec4(ambient, 1.0);
+	
 }

--- a/COMP371/water_frag.glsl
+++ b/COMP371/water_frag.glsl
@@ -71,7 +71,7 @@ void main() {
 	
 	
 	// Mix everything together
-	finalColor = mix(tempColor, texture(refractionTexture, uv + dudvDisp), 0.5);
+	finalColor = clamp(mix(tempColor, texture(refractionTexture, uv + dudvDisp), 0.5), 0.0,1.0);
 	
 	//finalColor = vec4(normal, 1.0);
 	//finalColor = vec4(specular,1.0);


### PR DESCRIPTION
There were some mistakes for the normals when calculating the light for the water, I also remodeled all our lighting to be more like the phong model.  The coefficients for ambient, diffuse, and specular are now material specific so right now they're hard coded in the fragment shaders.  If you want to darken the scene or make it sunset you should be modifying the color of the light since the color is what represents the intensity.